### PR TITLE
Set memory limits on all remaining containerized commands

### DIFF
--- a/.changeset/memory-limits-all-commands.md
+++ b/.changeset/memory-limits-all-commands.md
@@ -1,0 +1,5 @@
+---
+'@platforma-open/milaboratories.redefine-clonotypes.workflow': patch
+---
+
+Set explicit memory limits on remaining containerized commands to prevent OOM kills: xsv.importFile calls (8GiB), ANARCI (16GiB/4cpu), numbering script (8GiB/2cpu)

--- a/workflow/src/anarci-numbering.tpl.tengo
+++ b/workflow/src/anarci-numbering.tpl.tengo
@@ -32,6 +32,8 @@ self.body(func(inputs) {
 
     anarciBuilder := exec.builder().
         software(anarciSw).
+        cpu(4).
+        mem("16GiB").
         arg("-i").arg("input.fasta").
         arg("--scheme").arg(scheme).
         arg("--ncpu").argWithVar("{system.cpu}").
@@ -53,6 +55,8 @@ self.body(func(inputs) {
 
     numberingExec := exec.builder().
         software(numberingSw).
+        cpu(2).
+        mem("8GiB").
         addFile("input.tsv", inputTsv).
         arg("--input_tsv").arg("input.tsv").
         arg("--scheme").arg(scheme)

--- a/workflow/src/main.tpl.tengo
+++ b/workflow/src/main.tpl.tengo
@@ -1011,7 +1011,7 @@ wf.body(func(args) {
 		columns: newAbundanceColumns,
 		storageFormat: "Parquet",
 		partitionKeyLength: 1
-	}, { splitDataAndSpec: true })
+	}, { splitDataAndSpec: true, mem: "8GiB", cpu: 1 })
 
 	propertyAxes := [
 		{
@@ -1061,7 +1061,7 @@ wf.body(func(args) {
 		columns: newPropertyColumns,
 		storageFormat: "Parquet",
 		partitionKeyLength: 0
-	}, { splitDataAndSpec: true })
+	}, { splitDataAndSpec: true, mem: "8GiB", cpu: 1 })
 	
 
 	pfBuilder := pframes.pFrameBuilder()


### PR DESCRIPTION
## Summary
- Add explicit memory/cpu limits on all containerized commands that were missing them
- Follows up on #21 which fixed the `propertyTsvBuilder` OOM

### Changes
| Command | mem | cpu | Rationale |
|---------|-----|-----|-----------|
| `xsv.importFile` (abundances) | 8GiB | 1 | TSV→Parquet conversion, partitioned by sample |
| `xsv.importFile` (properties) | 8GiB | 1 | TSV→Parquet conversion, single partition |
| ANARCI (`anarciBuilder`) | 16GiB | 4 | HMM-based sequence alignment, cpu matches `--ncpu` |
| Numbering script (`numberingExec`) | 8GiB | 2 | Python data processing |

Both `xsv.importFile` calls internally create `pt.workflow().run()` via `importFileParquet`, running ptabler containers without memory limits — the same class of bug as #21.

## Test plan
- [ ] Run redefine-clonotypes with numbering enabled on a large dataset