### PR TITLE
Fix division error when input dataset contains no input clonotypes

### DIFF
--- a/.changeset/slow-monkeys-refuse.md
+++ b/.changeset/slow-monkeys-refuse.md
@@ -1,0 +1,8 @@
+---
+"@platforma-open/milaboratories.redefine-clonotypes.workflow": minor
+"@platforma-open/milaboratories.redefine-clonotypes": minor
+"@platforma-open/milaboratories.redefine-clonotypes.model": minor
+"@platforma-open/milaboratories.redefine-clonotypes.ui": minor
+---
+
+fix division error when there are no inputs

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,5 +1,6 @@
 {
   "recommendations": [
-    "dbaeumer.vscode-eslint"
-  ],
+    "dbaeumer.vscode-eslint",
+    "oxc.oxc-vscode"
+  ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,20 +1,51 @@
 {
-    "vitest.disableWorkspaceWarning": true,
-    "editor.defaultFormatter": "dbaeumer.vscode-eslint",
-    "[typescript]": {
-        "editor.defaultFormatter": "dbaeumer.vscode-eslint"
-    },
-    "[vue]": {
-        "editor.defaultFormatter": "dbaeumer.vscode-eslint"
-    },
-    "cSpell.words": [
-        "datasource",
-        "pframe",
-        "prerun"
-    ],
-    "editor.codeActionsOnSave": {
-        "source.fixAll.eslint": "always"
-    },
-    "eslint.enable": true,
-    "eslint.format.enable": true
+  "vitest.disableWorkspaceWarning": true,
+  "editor.defaultFormatter": "oxc.oxc-vscode",
+  "[typescript]": {
+    "editor.defaultFormatter": "oxc.oxc-vscode",
+    "editor.tabSize": 2
+  },
+  "[vue]": {
+    "editor.defaultFormatter": "oxc.oxc-vscode",
+    "editor.tabSize": 2
+  },
+  "cSpell.words": [
+    "datasource",
+    "pframe",
+    "prerun"
+  ],
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": "always"
+  },
+  "eslint.enable": true,
+  "eslint.format.enable": true,
+  "[javascript]": {
+    "editor.defaultFormatter": "oxc.oxc-vscode",
+    "editor.tabSize": 2
+  },
+  "[css]": {
+    "editor.defaultFormatter": "oxc.oxc-vscode",
+    "editor.tabSize": 2
+  },
+  "[scss]": {
+    "editor.defaultFormatter": "oxc.oxc-vscode",
+    "editor.tabSize": 2
+  },
+  "[html]": {
+    "editor.defaultFormatter": "oxc.oxc-vscode",
+    "editor.tabSize": 2
+  },
+  "[yaml]": {
+    "editor.defaultFormatter": "oxc.oxc-vscode",
+    "editor.tabSize": 2
+  },
+  "[markdown]": {
+    "editor.defaultFormatter": "oxc.oxc-vscode",
+    "editor.tabSize": 2
+  },
+  "[json]": {
+    "editor.defaultFormatter": "oxc.oxc-vscode",
+    "editor.tabSize": 2
+  },
+  "typescript.tsdk": "./node_modules/typescript/lib"
 }

--- a/block/package.json
+++ b/block/package.json
@@ -32,10 +32,9 @@
       "longDescription": "file:../docs/description.md",
       "changelog": "file:../CHANGELOG.md",
       "tags": [
-        "VDJ",
-        "clonotype",
-        "redefine",
-        "abundance"
+        "airr",
+        "vdj",
+        "downstream"
       ],
       "organization": {
         "name": "MiLaboratories Inc",

--- a/model/.oxfmtrc.json
+++ b/model/.oxfmtrc.json
@@ -1,0 +1,3 @@
+{
+  "ignorePatterns": ["dist", "CHANGELOG.md"]
+}

--- a/model/.oxlintrc.json
+++ b/model/.oxlintrc.json
@@ -1,0 +1,5 @@
+{
+  "extends": [
+    "node_modules/@milaboratories/ts-builder/dist/configs/oxlint-block-model.json"
+  ]
+}

--- a/model/eslint.config.mjs
+++ b/model/eslint.config.mjs
@@ -1,0 +1,4 @@
+import { model } from '@platforma-sdk/eslint-config';
+
+/** @type {import('eslint').Linter.Config[]} */
+export default [...model];

--- a/model/eslint.config.mjs
+++ b/model/eslint.config.mjs
@@ -1,4 +1,0 @@
-import { model } from '@platforma-sdk/eslint-config';
-
-/** @type {import('eslint').Linter.Config[]} */
-export default [...model];

--- a/model/src/index.ts
+++ b/model/src/index.ts
@@ -249,19 +249,6 @@ export const model = BlockModel.create()
     return parseNumberingStats(tsv);
   })
 
-  .output('numberingWarning', (ctx) => {
-    if (!ctx.args.numberingScheme) return undefined;
-    const tsv = ctx.outputs?.resolve({ field: 'numberingStatsContent', assertFieldType: 'Input', allowPermanentAbsence: true })?.getDataAsString();
-    const ns = parseNumberingStats(tsv);
-    if (!ns) return undefined;
-    if (ns.numbered === 0) {
-      return `ANARCI could not number any of the ${ns.total.toLocaleString()} clonotypes. The framework regions may be too divergent from known germline sequences.`;
-    }
-    if (ns.numbered < ns.total * 0.5) {
-      return `ANARCI could only number ${ns.numbered.toLocaleString()} of ${ns.total.toLocaleString()} clonotypes. The framework regions may be divergent from known germline sequences. Unnumbered clonotypes are excluded from the output.`;
-    }
-    return undefined;
-  })
   .output('anarciLog', (ctx) => {
     return ctx.outputs?.resolve({ field: 'anarciLog', assertFieldType: 'Input', allowPermanentAbsence: true })?.getLogHandle();
   })

--- a/package.json
+++ b/package.json
@@ -20,8 +20,13 @@
   "devDependencies": {
     "@changesets/cli": "catalog:",
     "@platforma-sdk/block-tools": "catalog:",
+    "@milaboratories/ts-builder": "catalog:",
     "turbo": "catalog:",
     "typescript": "catalog:"
   },
-  "packageManager": "pnpm@9.12.0"
+  "packageManager": "pnpm@9.12.0",
+  "peerDependencies": {
+    "oxlint": "*",
+    "oxfmt": "*"
+  }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -67,6 +67,13 @@ catalogs:
 importers:
 
   .:
+    dependencies:
+      oxfmt:
+        specifier: '*'
+        version: 0.35.0
+      oxlint:
+        specifier: '*'
+        version: 1.43.0
     devDependencies:
       '@changesets/cli':
         specifier: 'catalog:'
@@ -7476,20 +7483,6 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.3
 
-  '@vue/language-core@2.2.12(typescript@5.6.3)':
-    dependencies:
-      '@volar/language-core': 2.4.15
-      '@vue/compiler-dom': 3.5.26
-      '@vue/compiler-vue2': 2.7.16
-      '@vue/shared': 3.5.26
-      alien-signals: 1.0.13
-      minimatch: 9.0.5
-      muggle-string: 0.4.1
-      path-browserify: 1.0.1
-    optionalDependencies:
-      typescript: 5.6.3
-    optional: true
-
   '@vue/language-core@2.2.12(typescript@5.9.3)':
     dependencies:
       '@volar/language-core': 2.4.15
@@ -9188,7 +9181,7 @@ snapshots:
       rolldown: 1.0.0-rc.9
     optionalDependencies:
       typescript: 5.9.3
-      vue-tsc: 2.2.12(typescript@5.6.3)
+      vue-tsc: 2.2.12(typescript@5.9.3)
     transitivePeerDependencies:
       - oxc-resolver
 
@@ -9783,13 +9776,6 @@ snapshots:
       semver: 7.7.2
     transitivePeerDependencies:
       - supports-color
-
-  vue-tsc@2.2.12(typescript@5.6.3):
-    dependencies:
-      '@volar/typescript': 2.4.15
-      '@vue/language-core': 2.2.12(typescript@5.6.3)
-      typescript: 5.6.3
-    optional: true
 
   vue-tsc@2.2.12(typescript@5.9.3):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,29 +25,29 @@ catalogs:
       specifier: ^0.0.3
       version: 0.0.3
     '@platforma-sdk/block-tools':
-      specifier: 2.6.70
-      version: 2.6.70
+      specifier: 2.7.1
+      version: 2.7.1
     '@platforma-sdk/eslint-config':
       specifier: 1.2.0
       version: 1.2.0
     '@platforma-sdk/model':
-      specifier: 1.59.3
-      version: 1.59.3
+      specifier: 1.60.2
+      version: 1.60.2
     '@platforma-sdk/package-builder':
-      specifier: 3.11.6
-      version: 3.11.6
+      specifier: 3.12.0
+      version: 3.12.0
     '@platforma-sdk/tengo-builder':
-      specifier: 2.4.30
-      version: 2.4.30
+      specifier: 2.5.1
+      version: 2.5.1
     '@platforma-sdk/test':
-      specifier: 1.59.3
-      version: 1.59.3
+      specifier: 1.60.2
+      version: 1.60.2
     '@platforma-sdk/ui-vue':
-      specifier: 1.59.4
-      version: 1.59.4
+      specifier: 1.60.2
+      version: 1.60.2
     '@platforma-sdk/workflow-tengo':
-      specifier: 5.10.1
-      version: 5.10.1
+      specifier: 5.11.0
+      version: 5.11.0
     eslint:
       specifier: ^9.25.1
       version: 9.34.0
@@ -71,9 +71,12 @@ importers:
       '@changesets/cli':
         specifier: 'catalog:'
         version: 2.29.8(@types/node@24.5.2)
+      '@milaboratories/ts-builder':
+        specifier: 'catalog:'
+        version: 1.3.0(@types/node@24.5.2)(rollup@4.48.1)(vue@3.5.26(typescript@5.6.3))(yaml@2.8.1)
       '@platforma-sdk/block-tools':
         specifier: 'catalog:'
-        version: 2.6.70
+        version: 2.7.1
       turbo:
         specifier: 'catalog:'
         version: 2.7.3
@@ -94,11 +97,11 @@ importers:
         version: link:../workflow
       '@platforma-sdk/model':
         specifier: 'catalog:'
-        version: 1.59.3
+        version: 1.60.2
     devDependencies:
       '@platforma-sdk/block-tools':
         specifier: 'catalog:'
-        version: 2.6.70
+        version: 2.7.1
 
   model:
     dependencies:
@@ -107,7 +110,7 @@ importers:
         version: 0.1.2
       '@platforma-sdk/model':
         specifier: 'catalog:'
-        version: 1.59.3
+        version: 1.60.2
     devDependencies:
       '@milaboratories/ts-builder':
         specifier: 'catalog:'
@@ -117,7 +120,7 @@ importers:
         version: 1.2.2
       '@platforma-sdk/block-tools':
         specifier: 'catalog:'
-        version: 2.6.70
+        version: 2.7.1
       '@platforma-sdk/eslint-config':
         specifier: 'catalog:'
         version: 1.2.0(@eslint/js@9.34.0)(@stylistic/eslint-plugin@2.13.0(eslint@9.34.0)(typescript@5.6.3))(eslint-plugin-n@17.21.3(eslint@9.34.0)(typescript@5.6.3))(eslint-plugin-vue@9.33.0(eslint@9.34.0))(eslint@9.34.0)(globals@15.15.0)(typescript-eslint@8.41.0(eslint@9.34.0)(typescript@5.6.3))(typescript@5.6.3)
@@ -138,7 +141,7 @@ importers:
         version: 1.7.7
       '@platforma-sdk/package-builder':
         specifier: 'catalog:'
-        version: 3.11.6
+        version: 3.12.0
 
   software/assembling-fasta:
     devDependencies:
@@ -147,7 +150,7 @@ importers:
         version: 1.7.7
       '@platforma-sdk/package-builder':
         specifier: 'catalog:'
-        version: 3.11.6
+        version: 3.12.0
 
   test:
     dependencies:
@@ -166,7 +169,7 @@ importers:
         version: 1.2.0(@eslint/js@9.34.0)(@stylistic/eslint-plugin@2.13.0(eslint@9.34.0)(typescript@5.6.3))(eslint-plugin-n@17.21.3(eslint@9.34.0)(typescript@5.6.3))(eslint-plugin-vue@9.33.0(eslint@9.34.0))(eslint@9.34.0)(globals@15.15.0)(typescript-eslint@8.41.0(eslint@9.34.0)(typescript@5.6.3))(typescript@5.6.3)
       '@platforma-sdk/test':
         specifier: 'catalog:'
-        version: 1.59.3(@bytecodealliance/preview2-shim@0.17.8)(@types/node@24.5.2)(lightningcss@1.32.0)(yaml@2.8.1)
+        version: 1.60.2(@bytecodealliance/preview2-shim@0.17.8)(@types/node@24.5.2)(lightningcss@1.32.0)(yaml@2.8.1)
       eslint:
         specifier: 'catalog:'
         version: 9.34.0
@@ -184,10 +187,10 @@ importers:
         version: link:../model
       '@platforma-sdk/model':
         specifier: 'catalog:'
-        version: 1.59.3
+        version: 1.60.2
       '@platforma-sdk/ui-vue':
         specifier: 'catalog:'
-        version: 1.59.4(typescript@5.6.3)
+        version: 1.60.2(typescript@5.6.3)
       vue:
         specifier: 'catalog:'
         version: 3.5.26(typescript@5.6.3)
@@ -224,14 +227,14 @@ importers:
         version: 0.0.3
       '@platforma-sdk/workflow-tengo':
         specifier: 'catalog:'
-        version: 5.10.1
+        version: 5.11.0
     devDependencies:
       '@platforma-sdk/tengo-builder':
         specifier: 'catalog:'
-        version: 2.4.30
+        version: 2.5.1
       '@platforma-sdk/test':
         specifier: 'catalog:'
-        version: 1.59.3(@bytecodealliance/preview2-shim@0.17.8)(@types/node@24.5.2)(lightningcss@1.32.0)(yaml@2.8.1)
+        version: 1.60.2(@bytecodealliance/preview2-shim@0.17.8)(@types/node@24.5.2)(lightningcss@1.32.0)(yaml@2.8.1)
       vitest:
         specifier: 'catalog:'
         version: 4.0.9(@types/node@24.5.2)(lightningcss@1.32.0)(yaml@2.8.1)
@@ -935,8 +938,8 @@ packages:
   '@microsoft/tsdoc@0.15.1':
     resolution: {integrity: sha512-4aErSrCR/On/e5G2hDP0wjooqDdauzEbIq8hIkIe5pXV0rtWJZvdCEKL0ykZxex+IxIwBp0eGeV48hQN07dXtw==}
 
-  '@milaboratories/computable@2.8.6':
-    resolution: {integrity: sha512-7LxXgX6H66wCN69/zKGVGRv8HalU7+6b+oDzpba5dfDPPzajG0h/mG2aZ8o+/3leUDZtsg5ACewvV/CkSo832Q==}
+  '@milaboratories/computable@2.9.0':
+    resolution: {integrity: sha512-W1/Y24zjSlONetigr9i7lYDbSIvCeU6w3iuqyRo5ZREq8WGrHRNwl0a1bpwQGmDnn0I0SZa1tLj3d72aOjNsVg==}
     engines: {node: '>=22.19.0'}
 
   '@milaboratories/helpers@1.13.5':
@@ -947,8 +950,12 @@ packages:
     resolution: {integrity: sha512-3OY8A0VmXAZEAb12fIaHi8CXXjiap2jSFDAXNrh7uabGbjpg4ZiP1g1xHhDcpbaIVlPIBB/4vlEGLhk9aScQsg==}
     engines: {node: '>=22'}
 
-  '@milaboratories/pf-driver@1.0.68':
-    resolution: {integrity: sha512-Yd3dvbw9p1gssXmvkHym6OlY0cOdJJmXSl02DsgBSl/fOZYhPknigboJAX2biZg3I3/ukfREsduier+M2xrwCg==}
+  '@milaboratories/helpers@1.14.0':
+    resolution: {integrity: sha512-lKzbuUJHBiGEVxqS9+EaYkuMAQt0iAohQUiIviu+2rNZHrTIvJGLBIiLBHC7fmjJM45xCKzyLG6c0tPjDUi2kQ==}
+    engines: {node: '>=22'}
+
+  '@milaboratories/pf-driver@1.1.1':
+    resolution: {integrity: sha512-Wd/Z3e42iFNiIC93TKBdOqrflCl0TXJq+MM3ZtQ2dIEJJFSDGLbl1o+lWSVy/lNPyAHp4YiAIKpaXOJYU2nZ4A==}
     engines: {node: '>=22.19.0'}
 
   '@milaboratories/pframes-rs-node@1.1.14':
@@ -965,58 +972,58 @@ packages:
       '@milaboratories/pl-model-common': 1.26.0
       '@milaboratories/pl-model-middle-layer': 1.13.0
 
-  '@milaboratories/pl-client@2.17.12':
-    resolution: {integrity: sha512-x7rnsEvNhQFdzb9IMwslnx44j2o/8qglFsOhyTqU1VNGW5WvOuUPYXsOwkq0hZlaO32Mn4NGHnNhcmLxZP4nYA==}
+  '@milaboratories/pl-client@2.18.1':
+    resolution: {integrity: sha512-a+Vm+j2WuQ+aSSbOsHkBKiHEIjRpBFNWom830oMqXPX8D6y2OLkU+mcP8vXNnf+0tHQASydh1YYqKAHEdxLfyQ==}
     engines: {node: '>=22.19.0'}
 
   '@milaboratories/pl-config@1.7.15':
     resolution: {integrity: sha512-XYkyYdoPFGtxIVogCmQ6tGupUBoi1gtfLnTdd/i8Qqfnk/P673hr8TTH+CBAglqNbrg+jubw4oYO4cLpGIEzfA==}
 
-  '@milaboratories/pl-deployments@2.15.24':
-    resolution: {integrity: sha512-rix8dqIIoPJmLOeM2iFgK1fABB8b4uPmQZXw7IPtPiMm5coEHVVE39WQWCDAgnuPqpopSI/knNaAcvESB63cyw==}
+  '@milaboratories/pl-deployments@2.16.1':
+    resolution: {integrity: sha512-W/UrLAYNGm7173wc6Zz4HipTWye/rqBaYj+Jp9WPo3uuSuMQWUql34h2JM0X+EkpihEh2reiajDQ0rvdOYD8ug==}
     engines: {node: '>=22.19.0'}
 
-  '@milaboratories/pl-drivers@1.11.66':
-    resolution: {integrity: sha512-QBa0q/s51CctCunrqJLkpl51/IsFFMaXJd9t0z1YTPkIbMMdawhzE/PAh4Q/EWkNOQpDnkji5+kBMB3ESPm4lQ==}
+  '@milaboratories/pl-drivers@1.12.2':
+    resolution: {integrity: sha512-5ivviwrJUumo7Q8DssGhkfhl4ampet10IBIGQIyui1mMCDsR1Wc31ggnsHISr/EHpgMj0SNahk7uzjQR4SRu2g==}
     engines: {node: '>=22'}
 
   '@milaboratories/pl-error-like@1.12.9':
     resolution: {integrity: sha512-9qlfawLFO4qG656ayvVSRholhhwlfXUvKKllXpHadqbnf2zO2oCd+5J76bPaFXDz/A3T+1eokCnCX74JsqCYSw==}
 
-  '@milaboratories/pl-errors@1.1.74':
-    resolution: {integrity: sha512-oeQ4+/UN4mVoZ0/ZP5K+56usP96W7YjR+jUtjDeUOkcADykecbnpjUMkaXx23hPo3u6MT9Pci9UkKjZFxtdfcw==}
+  '@milaboratories/pl-errors@1.2.1':
+    resolution: {integrity: sha512-YE0lAIDd6E53jDLKqT1E+EDwif73w6/J2CDqbbypLnWUQlNfc1LAfNo+zyYEPB7zcR8yaEbJ4vg/sDvlNqe2Bg==}
 
   '@milaboratories/pl-http@1.2.4':
     resolution: {integrity: sha512-QKmhx+WEvJCV9dUy/SBdQk/ApaJ5ewBFgm/b+XPlS10SusAdqUUTGvK5+hq8YSuUMXlHb/dk++UtI5YlDuDl2Q==}
 
-  '@milaboratories/pl-middle-layer@1.48.28':
-    resolution: {integrity: sha512-1yu6oCRDSDxPX3Kjs3ET5QkT6M54Y8prMUK8UkaUBH9t7rlEf+XycpoYY2O80ThS2XU1oAZPm7CD0tsbM9cWKw==}
+  '@milaboratories/pl-middle-layer@1.52.1':
+    resolution: {integrity: sha512-A9qYRW3eegL/2gWG4IsNrZXCxRaNwCSLHh9Rq6QDLTCHVhnnEz9uQLgaX662PnuuKOaiYmkWVNFpmHenZ3/BUw==}
     engines: {node: '>=22.19.0'}
 
-  '@milaboratories/pl-model-backend@1.1.59':
-    resolution: {integrity: sha512-pz+WbNrCCvkEYmyJ5JRJ2gHg3lDn/Gfq31Z+7KzuEv574bEnuucqJDqX/T8W4j68FOTZD8rfQ0J9kUEmrTwtMQ==}
+  '@milaboratories/pl-model-backend@1.2.1':
+    resolution: {integrity: sha512-5TGyJhCoAjog9cswXLaIY3PTap5QRSQK/m+P+GIoCBSyqhsMY9FGPfk3s+oEh42N6W48KUP0/gTTCCKv3mzLLQ==}
 
   '@milaboratories/pl-model-common@1.26.0':
     resolution: {integrity: sha512-HnbKSMOS2QXvlrDLo8ltC6Q2j9rpiPDsXsBDY+pDxq5Sw3AtSV3EKFqXj6tUAIeWf0WI1Fmat5NFHMiYKg/ejA==}
 
-  '@milaboratories/pl-model-common@1.26.1':
-    resolution: {integrity: sha512-iuXuXxwLDM9oWludojpQFJDgsHRuqhP98VEJIOoJC186TidYcyUIib4AkUjz5sol81fpZLjrtbul7eU4NDDQng==}
+  '@milaboratories/pl-model-common@1.28.0':
+    resolution: {integrity: sha512-VGfXSzep5LR8vnj7El0ksDiZEmELhT8jB7EeXv3VIOmYZj4cPYbkNsb+54wrBloMzyIc1iG1H13ucR44qbv/bw==}
 
   '@milaboratories/pl-model-middle-layer@1.13.0':
     resolution: {integrity: sha512-FBgu0rdUoXcDMzjrgLXUdwRJtyv5BKLHgJ2fVwtDapjGCWxmLzeW7QeFo+VpLJPimxnuOXoZBxFcn7p1gfZuLQ==}
 
-  '@milaboratories/pl-model-middle-layer@1.13.1':
-    resolution: {integrity: sha512-VlEXJjyabUszlK5Vi2bJFGxEI9qTB/ifyDSsGRoGrKXp8DDtBhUw8cTWT1A/NWt5uoAQcAlGhQzUxRIH/ygKlQ==}
+  '@milaboratories/pl-model-middle-layer@1.15.0':
+    resolution: {integrity: sha512-uYb/H+rYWSY4IckYxKClQF6yLv+yOJMqtIfJusd7MuCn29HYeQLMruowNaf9A/O35bFx5gqAeiF7XDCn2iQHNA==}
 
-  '@milaboratories/pl-tree@1.8.52':
-    resolution: {integrity: sha512-gJ354IazTwf4ffe/85Pzx9vPIrfFwKevC19PbO/hkxpbjZde1ua7zQnUPcFJBCZ6Fnb8Xt8nfnB7OCZulbhFxw==}
+  '@milaboratories/pl-tree@1.9.2':
+    resolution: {integrity: sha512-U2FZ5B0G3kRFXNz1RWq7OmWSHcuBL+KUxfQT8DphYZJ9B3gB4OpMGuhFWYkn4/SZDv9o0zgQIjdaYQYr3krCZw==}
     engines: {node: '>=22.19.0'}
 
   '@milaboratories/ptabler-expression-js@1.1.26':
     resolution: {integrity: sha512-/oUXPQmU5pfz4pK47Qg372crouD1FCo9Ywo+rD50d8oIWeoXZ+mGo1DtCeHC/eiL8rCLIIF4IQnnoYn00KqgfA==}
 
-  '@milaboratories/ptabler-expression-js@1.1.27':
-    resolution: {integrity: sha512-Cr31YNdep1B2yRn0C8XOBRCswuQbcTCnElxfkqgk6Qr9LcH6oXOYq+LgBMhODbYXBQSxIv4qrKbr2aGif7wiVQ==}
+  '@milaboratories/ptabler-expression-js@1.2.1':
+    resolution: {integrity: sha512-xNDSLiGvRiTY8QiCJg5mGwsT79YXmkXr607O0brUM1EQGXMODQLy1I6nnWDOXerQBA66MzJ7Cuv0MTK94cavVA==}
 
   '@milaboratories/resolve-helper@1.1.3':
     resolution: {integrity: sha512-38/dW/XRZQREOxAOOKtO0lzEWPCP/DH0qhB3q1kYcGoN++5V92/zbVwbYrMDeDcjTyo+D62iIep+sKXeWHa7Uw==}
@@ -1046,8 +1053,8 @@ packages:
     resolution: {integrity: sha512-65/URvZfb5moAyIaRKoExjam5ZcXHg9EyepFU7dnUBpPaW0q5+HTS6ThQDIiGJk63qwXe9qyyDgIbSqyhFWulw==}
     engines: {node: '>=22.19.0'}
 
-  '@milaboratories/uikit@2.10.46':
-    resolution: {integrity: sha512-Alc4QAkuhQdYW+kEiTyX8+EALz5EpZAyFp4CwJDjMxN9sGyX9aMRhxdqNBQkjThn0P56kImb2+zGxxfSjzKTYw==}
+  '@milaboratories/uikit@2.11.1':
+    resolution: {integrity: sha512-l3L6sY2wk03ZSsffi7mr9XU+Zt3LXoYWYY1lGvS8Z+eAcpNzcgvljDjn2eREH/z29suBiaIw0TQzOuY+PnvuRw==}
 
   '@napi-rs/wasm-runtime@1.1.1':
     resolution: {integrity: sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A==}
@@ -1301,11 +1308,11 @@ packages:
   '@platforma-open/milaboratories.software-ptabler.schema@1.13.19':
     resolution: {integrity: sha512-S1g5idMNu3KL2AdWKwivCgd0ZRwXrpCK+TkhAfuXBafezRwHAw0k+A1F62BY7OBA8pOGd5R7yvU2LpMpCnaPOQ==}
 
-  '@platforma-open/milaboratories.software-ptabler.schema@1.13.20':
-    resolution: {integrity: sha512-59rUZzQm/UE/Y2F/Q8IidjAjZjgM5uP/Atn0WbEMoaQrxt7Xc//Et2dIbY9KsdjTwbiMkZzLvvBZvJA0q3uwYA==}
+  '@platforma-open/milaboratories.software-ptabler.schema@1.14.1':
+    resolution: {integrity: sha512-T5+RrW1u+eBWorvsFKcVOOtiWVgoj4DpICAYKr7Auiv5cgCfZy3xWWTYxnXdFjrd4pz7g/Jo+4yuRcDSo9WkaQ==}
 
-  '@platforma-open/milaboratories.software-ptabler@1.14.3':
-    resolution: {integrity: sha512-nN0Z/+ZTK3DD4mD1LyYTd7bees+bL/YJYX5djf7Xj0cpWxCzvYDe0G3tTK6koejmAjiD48/3LfESDUxrUbpyBA==}
+  '@platforma-open/milaboratories.software-ptabler@1.15.0':
+    resolution: {integrity: sha512-7hbuOsIU3WsmAsBwWoVfP1UyZPBQj/Ec8KGoUBoaAq5VNjVQ7oQR3Nx4co+dIJJ9+cEB3c633Xx1DNxebb5uNQ==}
 
   '@platforma-open/milaboratories.software-ptexter@1.2.2':
     resolution: {integrity: sha512-I08YpKQ4+esLrfpVra5UJ+bznI9Zzba6OW0rKK407a1EUmanvYMVrCbM9gqnm6CHbv2vQxNGSaO8p1LoBh+9gA==}
@@ -1325,12 +1332,12 @@ packages:
   '@platforma-open/milaboratories.software-small-binaries@2.0.2':
     resolution: {integrity: sha512-/ViK6kJDjCL/0jBFuEqLwSrpLK4afnR4XiHFOvIlaiYgWHeRU4Gw3aCSMRo6lhG3r6YeeWBqZ9FCkGKKy3TPvg==}
 
-  '@platforma-sdk/block-tools@2.6.70':
-    resolution: {integrity: sha512-PnPKuPRybupHybmzImC87r7lM9qa9f6KoPYIYJLNAMFWo8oNDrTZe2yRXJpMvpGvXahLGrErmrttGdvVoUJ8Sg==}
+  '@platforma-sdk/block-tools@2.7.1':
+    resolution: {integrity: sha512-1U99O9OcZugrsnIt9WtAFbUxBmbBlEKf57T3haLqulqrAjhXOmK1JTPx/jvZJDbJOCCeIJKeD3EWinrhRFswfw==}
     hasBin: true
 
-  '@platforma-sdk/blocks-deps-updater@2.1.0':
-    resolution: {integrity: sha512-a/kiOnzAaLAYXleCLmY6XlYygLSumQRa8AwKwImyR19OGU9I3QDs4ccyuvLrasYd/ZQJRD1PZIlSUj4OxpixFQ==}
+  '@platforma-sdk/blocks-deps-updater@2.2.0':
+    resolution: {integrity: sha512-p9lBxhFXM9WoRsrJO7dfkiXSK+1m63yIn1sKhBO71eMbhrLMyVYHEOeNf3w5OCdbRF5QsNhXzWuiTmFK3zHFsA==}
     hasBin: true
 
   '@platforma-sdk/eslint-config@1.2.0':
@@ -1348,26 +1355,26 @@ packages:
   '@platforma-sdk/model@1.59.0':
     resolution: {integrity: sha512-v+HiC04Bf6QinIo1zAQxvB1gzVP3JbDLuraGNs/dCeF1abhV0aq/+QfFq1o9xEHqiyNS2IugOLXH03PoL7JRoA==}
 
-  '@platforma-sdk/model@1.59.3':
-    resolution: {integrity: sha512-RLQqfmPZfa63DbzyhhstAwLVJ68oxiqyxs+reim8AEGKJGt0G9W3Ae1agn0BwylXqPDX6z+0lcJ9mmVVUk+WkQ==}
+  '@platforma-sdk/model@1.60.2':
+    resolution: {integrity: sha512-gf2ZBcg8q1EwU2vEH+xRUVyTcuQyl1kvrBn039qc1M7n8+yQeeEJUWBxNyzLG791g2y2XskAHSUguzMYuoWVGg==}
 
-  '@platforma-sdk/package-builder@3.11.6':
-    resolution: {integrity: sha512-USg3EloqmV0c66WIPM48I7TnpIau+Mmk+cPtq0el69mTy8xN7YfgN9o8XHlzWvBWuloecWzmOVAAE9VQKFHOAA==}
+  '@platforma-sdk/package-builder@3.12.0':
+    resolution: {integrity: sha512-bId52YqV5iLDAn9D9C3xaLD1bKyymGpHe2CDEZTqV+1yWCBh1RM6iH96JIXudVJdcmJaqwJWDw6X4WzStE6SCg==}
     hasBin: true
 
-  '@platforma-sdk/tengo-builder@2.4.30':
-    resolution: {integrity: sha512-/gW8AAdoF6g2qxMOFrHQTeMKH4zkIcOUkeLr+BOm1Q27cRUfEHLK3I3Mw49OKZvTIhmyIXM6Q5MLQAThyqMkAw==}
+  '@platforma-sdk/tengo-builder@2.5.1':
+    resolution: {integrity: sha512-5tpS32dv4kfxsIz+XlOF6y5rm2oCjDn4ejqvWN0HA8zJDHfL4xkp6G7PQuJF9su/ms8GEQU88esYJJjEzhHurA==}
     engines: {node: '>=22'}
     hasBin: true
 
-  '@platforma-sdk/test@1.59.3':
-    resolution: {integrity: sha512-V+98rVxCPnnP13jVJokCec5sBsIBZ1Vh0tI1yIMZWf3g255Q7uhCk4puh3gdX6QdIgF13VoGT/AzUwweqguZow==}
+  '@platforma-sdk/test@1.60.2':
+    resolution: {integrity: sha512-ygTenV0PSdVqP2QCgCHR+x6nmY9pQP/U5yssYHMJkYkmBLqlb8nPsJHFZOsHrUn96m9EteWwtMaO5y/Jb5mRXw==}
 
-  '@platforma-sdk/ui-vue@1.59.4':
-    resolution: {integrity: sha512-ahytv+ePqO+xb/2TE4iUvz+ZcLjEnwACmegsGJlz3b7k9rMY8dLDPLhoY7kMlNgQIyiqxJ14jrOl+X52qJuWig==}
+  '@platforma-sdk/ui-vue@1.60.2':
+    resolution: {integrity: sha512-1wqzJOmVlTzkt3XRUKXIfHcKFzZdZrDjZIEAZlDZNq61dMeKxglq096Nw+ayVAwgk2Pr2kZSYskFPYV5HGLsCw==}
 
-  '@platforma-sdk/workflow-tengo@5.10.1':
-    resolution: {integrity: sha512-OXAdjL1cTDzgm/C8+2YdEuUNpKCkd6XMp1CKGxSN6K9Wi2wXGQSczb7motYk4ho1Yrd1ykkNoWuX2tBz9H+JzA==}
+  '@platforma-sdk/workflow-tengo@5.11.0':
+    resolution: {integrity: sha512-+jH4xSqWABB6DCKFvfWrUVYuoBwWrfNObGi9a1zSWvAQZFw++V5nlJLG0nfdoTNnCXiXBl+9nseMenjDBMM6kg==}
 
   '@protobuf-ts/grpc-transport@2.11.1':
     resolution: {integrity: sha512-l6wrcFffY+tuNnuyrNCkRM8hDIsAZVLA8Mn7PKdVyYxITosYh60qW663p9kL6TWXYuDCL3oxH8ih3vLKTDyhtg==}
@@ -5788,7 +5795,7 @@ snapshots:
 
   '@microsoft/tsdoc@0.15.1': {}
 
-  '@milaboratories/computable@2.8.6':
+  '@milaboratories/computable@2.9.0':
     dependencies:
       '@milaboratories/pl-error-like': 1.12.9
       '@milaboratories/ts-helpers': 1.7.3
@@ -5799,18 +5806,19 @@ snapshots:
 
   '@milaboratories/helpers@1.13.7': {}
 
-  '@milaboratories/pf-driver@1.0.68(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@1.26.1)':
+  '@milaboratories/helpers@1.14.0': {}
+
+  '@milaboratories/pf-driver@1.1.1(@bytecodealliance/preview2-shim@0.17.8)':
     dependencies:
       '@milaboratories/pframes-rs-node': 1.1.14
-      '@milaboratories/pframes-rs-wasm': 1.1.14(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@1.26.1)(@milaboratories/pl-model-middle-layer@1.13.1)
-      '@milaboratories/pl-model-middle-layer': 1.13.1
+      '@milaboratories/pframes-rs-wasm': 1.1.14(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@1.28.0)(@milaboratories/pl-model-middle-layer@1.15.0)
+      '@milaboratories/pl-model-common': 1.28.0
+      '@milaboratories/pl-model-middle-layer': 1.15.0
       '@milaboratories/ts-helpers': 1.7.3
-      '@platforma-sdk/model': 1.59.3
       es-toolkit: 1.40.0
       lru-cache: 11.2.2
     transitivePeerDependencies:
       - '@bytecodealliance/preview2-shim'
-      - '@milaboratories/pl-model-common'
       - encoding
       - supports-color
 
@@ -5833,17 +5841,17 @@ snapshots:
       commander: 14.0.3
       selfsigned: 5.5.0
 
-  '@milaboratories/pframes-rs-wasm@1.1.14(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@1.26.1)(@milaboratories/pl-model-middle-layer@1.13.1)':
+  '@milaboratories/pframes-rs-wasm@1.1.14(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@1.28.0)(@milaboratories/pl-model-middle-layer@1.15.0)':
     dependencies:
       '@bytecodealliance/preview2-shim': 0.17.8
-      '@milaboratories/pl-model-common': 1.26.1
-      '@milaboratories/pl-model-middle-layer': 1.13.1
+      '@milaboratories/pl-model-common': 1.28.0
+      '@milaboratories/pl-model-middle-layer': 1.15.0
 
-  '@milaboratories/pl-client@2.17.12':
+  '@milaboratories/pl-client@2.18.1':
     dependencies:
       '@grpc/grpc-js': 1.13.4
       '@milaboratories/pl-http': 1.2.4
-      '@milaboratories/pl-model-common': 1.26.1
+      '@milaboratories/pl-model-common': 1.28.0
       '@milaboratories/ts-helpers': 1.7.3
       '@protobuf-ts/grpc-transport': 2.11.1(@grpc/grpc-js@1.13.4)
       '@protobuf-ts/runtime': 2.11.1
@@ -5863,11 +5871,11 @@ snapshots:
       upath: 2.0.1
       yaml: 2.8.1
 
-  '@milaboratories/pl-deployments@2.15.24':
+  '@milaboratories/pl-deployments@2.16.1':
     dependencies:
       '@milaboratories/pl-config': 1.7.15
       '@milaboratories/pl-http': 1.2.4
-      '@milaboratories/pl-model-common': 1.26.1
+      '@milaboratories/pl-model-common': 1.28.0
       '@milaboratories/ts-helpers': 1.7.3
       decompress: 4.2.1
       ssh2: 1.17.0
@@ -5877,14 +5885,14 @@ snapshots:
       yaml: 2.8.1
       zod: 3.23.8
 
-  '@milaboratories/pl-drivers@1.11.66':
+  '@milaboratories/pl-drivers@1.12.2':
     dependencies:
       '@grpc/grpc-js': 1.13.4
-      '@milaboratories/computable': 2.8.6
-      '@milaboratories/helpers': 1.13.7
-      '@milaboratories/pl-client': 2.17.12
-      '@milaboratories/pl-model-common': 1.26.1
-      '@milaboratories/pl-tree': 1.8.52
+      '@milaboratories/computable': 2.9.0
+      '@milaboratories/helpers': 1.14.0
+      '@milaboratories/pl-client': 2.18.1
+      '@milaboratories/pl-model-common': 1.28.0
+      '@milaboratories/pl-tree': 1.9.2
       '@milaboratories/ts-helpers': 1.7.3
       '@protobuf-ts/grpc-transport': 2.11.1(@grpc/grpc-js@1.13.4)
       '@protobuf-ts/plugin': 2.11.1
@@ -5905,9 +5913,9 @@ snapshots:
       json-stringify-safe: 5.0.1
       zod: 3.23.8
 
-  '@milaboratories/pl-errors@1.1.74':
+  '@milaboratories/pl-errors@1.2.1':
     dependencies:
-      '@milaboratories/pl-client': 2.17.12
+      '@milaboratories/pl-client': 2.18.1
       '@milaboratories/ts-helpers': 1.7.3
       zod: 3.23.8
 
@@ -5915,25 +5923,26 @@ snapshots:
     dependencies:
       undici: 7.16.0
 
-  '@milaboratories/pl-middle-layer@1.48.28(@bytecodealliance/preview2-shim@0.17.8)':
+  '@milaboratories/pl-middle-layer@1.52.1(@bytecodealliance/preview2-shim@0.17.8)':
     dependencies:
-      '@milaboratories/computable': 2.8.6
-      '@milaboratories/pf-driver': 1.0.68(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@1.26.1)
+      '@milaboratories/computable': 2.9.0
+      '@milaboratories/pf-driver': 1.1.1(@bytecodealliance/preview2-shim@0.17.8)
       '@milaboratories/pframes-rs-node': 1.1.14
-      '@milaboratories/pl-client': 2.17.12
-      '@milaboratories/pl-deployments': 2.15.24
-      '@milaboratories/pl-drivers': 1.11.66
-      '@milaboratories/pl-errors': 1.1.74
+      '@milaboratories/pframes-rs-wasm': 1.1.14(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@1.28.0)(@milaboratories/pl-model-middle-layer@1.15.0)
+      '@milaboratories/pl-client': 2.18.1
+      '@milaboratories/pl-deployments': 2.16.1
+      '@milaboratories/pl-drivers': 1.12.2
+      '@milaboratories/pl-errors': 1.2.1
       '@milaboratories/pl-http': 1.2.4
-      '@milaboratories/pl-model-backend': 1.1.59
-      '@milaboratories/pl-model-common': 1.26.1
-      '@milaboratories/pl-model-middle-layer': 1.13.1
-      '@milaboratories/pl-tree': 1.8.52
+      '@milaboratories/pl-model-backend': 1.2.1
+      '@milaboratories/pl-model-common': 1.28.0
+      '@milaboratories/pl-model-middle-layer': 1.15.0
+      '@milaboratories/pl-tree': 1.9.2
       '@milaboratories/resolve-helper': 1.1.3
       '@milaboratories/ts-helpers': 1.7.3
-      '@platforma-sdk/block-tools': 2.6.70
-      '@platforma-sdk/model': 1.59.3
-      '@platforma-sdk/workflow-tengo': 5.10.1
+      '@platforma-sdk/block-tools': 2.7.1
+      '@platforma-sdk/model': 1.60.2
+      '@platforma-sdk/workflow-tengo': 5.11.0
       canonicalize: 2.1.0
       denque: 2.1.0
       es-toolkit: 1.40.0
@@ -5950,9 +5959,9 @@ snapshots:
       - encoding
       - supports-color
 
-  '@milaboratories/pl-model-backend@1.1.59':
+  '@milaboratories/pl-model-backend@1.2.1':
     dependencies:
-      '@milaboratories/pl-client': 2.17.12
+      '@milaboratories/pl-client': 2.18.1
       canonicalize: 2.1.0
       zod: 3.23.8
 
@@ -5962,8 +5971,9 @@ snapshots:
       canonicalize: 2.1.0
       zod: 3.23.8
 
-  '@milaboratories/pl-model-common@1.26.1':
+  '@milaboratories/pl-model-common@1.28.0':
     dependencies:
+      '@milaboratories/helpers': 1.14.0
       '@milaboratories/pl-error-like': 1.12.9
       canonicalize: 2.1.0
       zod: 3.23.8
@@ -5976,19 +5986,19 @@ snapshots:
       utility-types: 3.11.0
       zod: 3.23.8
 
-  '@milaboratories/pl-model-middle-layer@1.13.1':
+  '@milaboratories/pl-model-middle-layer@1.15.0':
     dependencies:
-      '@milaboratories/pl-model-common': 1.26.1
-      '@platforma-sdk/model': 1.59.3
+      '@milaboratories/helpers': 1.14.0
+      '@milaboratories/pl-model-common': 1.28.0
       es-toolkit: 1.40.0
       utility-types: 3.11.0
       zod: 3.23.8
 
-  '@milaboratories/pl-tree@1.8.52':
+  '@milaboratories/pl-tree@1.9.2':
     dependencies:
-      '@milaboratories/computable': 2.8.6
-      '@milaboratories/pl-client': 2.17.12
-      '@milaboratories/pl-errors': 1.1.74
+      '@milaboratories/computable': 2.9.0
+      '@milaboratories/pl-client': 2.18.1
+      '@milaboratories/pl-errors': 1.2.1
       '@milaboratories/ts-helpers': 1.7.3
       denque: 2.1.0
       utility-types: 3.11.0
@@ -5998,9 +6008,9 @@ snapshots:
     dependencies:
       '@platforma-open/milaboratories.software-ptabler.schema': 1.13.19
 
-  '@milaboratories/ptabler-expression-js@1.1.27':
+  '@milaboratories/ptabler-expression-js@1.2.1':
     dependencies:
-      '@platforma-open/milaboratories.software-ptabler.schema': 1.13.20
+      '@platforma-open/milaboratories.software-ptabler.schema': 1.14.1
 
   '@milaboratories/resolve-helper@1.1.3': {}
 
@@ -6062,10 +6072,10 @@ snapshots:
       canonicalize: 2.1.0
       denque: 2.1.0
 
-  '@milaboratories/uikit@2.10.46(typescript@5.6.3)':
+  '@milaboratories/uikit@2.11.1(typescript@5.6.3)':
     dependencies:
-      '@milaboratories/helpers': 1.13.7
-      '@platforma-sdk/model': 1.59.3
+      '@milaboratories/helpers': 1.14.0
+      '@platforma-sdk/model': 1.60.2
       '@types/d3-array': 3.2.1
       '@types/d3-axis': 3.0.6
       '@types/d3-scale': 4.0.9
@@ -6344,11 +6354,11 @@ snapshots:
     dependencies:
       '@milaboratories/pl-model-common': 1.26.0
 
-  '@platforma-open/milaboratories.software-ptabler.schema@1.13.20':
+  '@platforma-open/milaboratories.software-ptabler.schema@1.14.1':
     dependencies:
-      '@milaboratories/pl-model-common': 1.26.1
+      '@milaboratories/pl-model-common': 1.28.0
 
-  '@platforma-open/milaboratories.software-ptabler@1.14.3': {}
+  '@platforma-open/milaboratories.software-ptabler@1.15.0': {}
 
   '@platforma-open/milaboratories.software-ptexter@1.2.2': {}
 
@@ -6367,17 +6377,17 @@ snapshots:
       '@platforma-open/milaboratories.software-small-binaries.mnz-client': 1.6.3
       '@platforma-open/milaboratories.software-small-binaries.table-converter': 1.3.3
 
-  '@platforma-sdk/block-tools@2.6.70':
+  '@platforma-sdk/block-tools@2.7.1':
     dependencies:
       '@aws-sdk/client-s3': 3.859.0
       '@milaboratories/pl-http': 1.2.4
-      '@milaboratories/pl-model-common': 1.26.1
-      '@milaboratories/pl-model-middle-layer': 1.13.1
+      '@milaboratories/pl-model-common': 1.28.0
+      '@milaboratories/pl-model-middle-layer': 1.15.0
       '@milaboratories/resolve-helper': 1.1.3
       '@milaboratories/ts-helpers': 1.7.3
       '@milaboratories/ts-helpers-oclif': 1.1.38
       '@oclif/core': 4.5.2
-      '@platforma-sdk/blocks-deps-updater': 2.1.0
+      '@platforma-sdk/blocks-deps-updater': 2.2.0
       canonicalize: 2.1.0
       lru-cache: 11.2.2
       mime-types: 2.1.35
@@ -6388,7 +6398,7 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
-  '@platforma-sdk/blocks-deps-updater@2.1.0':
+  '@platforma-sdk/blocks-deps-updater@2.2.0':
     dependencies:
       yaml: 2.8.1
 
@@ -6415,19 +6425,20 @@ snapshots:
       utility-types: 3.11.0
       zod: 3.23.8
 
-  '@platforma-sdk/model@1.59.3':
+  '@platforma-sdk/model@1.60.2':
     dependencies:
-      '@milaboratories/helpers': 1.13.7
+      '@milaboratories/helpers': 1.14.0
       '@milaboratories/pl-error-like': 1.12.9
-      '@milaboratories/pl-model-common': 1.26.1
-      '@milaboratories/ptabler-expression-js': 1.1.27
+      '@milaboratories/pl-model-common': 1.28.0
+      '@milaboratories/pl-model-middle-layer': 1.15.0
+      '@milaboratories/ptabler-expression-js': 1.2.1
       canonicalize: 2.1.0
       es-toolkit: 1.40.0
       fast-json-patch: 3.1.1
       utility-types: 3.11.0
       zod: 3.23.8
 
-  '@platforma-sdk/package-builder@3.11.6':
+  '@platforma-sdk/package-builder@3.12.0':
     dependencies:
       '@aws-sdk/client-s3': 3.859.0
       '@aws-sdk/lib-storage': 3.859.0(@aws-sdk/client-s3@3.859.0)
@@ -6443,21 +6454,21 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
-  '@platforma-sdk/tengo-builder@2.4.30':
+  '@platforma-sdk/tengo-builder@2.5.1':
     dependencies:
-      '@milaboratories/pl-model-backend': 1.1.59
+      '@milaboratories/pl-model-backend': 1.2.1
       '@milaboratories/resolve-helper': 1.1.3
       '@milaboratories/tengo-tester': 1.6.4
       '@milaboratories/ts-helpers': 1.7.3
       '@oclif/core': 4.5.2
       winston: 3.17.0
 
-  '@platforma-sdk/test@1.59.3(@bytecodealliance/preview2-shim@0.17.8)(@types/node@24.5.2)(lightningcss@1.32.0)(yaml@2.8.1)':
+  '@platforma-sdk/test@1.60.2(@bytecodealliance/preview2-shim@0.17.8)(@types/node@24.5.2)(lightningcss@1.32.0)(yaml@2.8.1)':
     dependencies:
-      '@milaboratories/computable': 2.8.6
-      '@milaboratories/pl-client': 2.17.12
-      '@milaboratories/pl-middle-layer': 1.48.28(@bytecodealliance/preview2-shim@0.17.8)
-      '@milaboratories/pl-tree': 1.8.52
+      '@milaboratories/computable': 2.9.0
+      '@milaboratories/pl-client': 2.18.1
+      '@milaboratories/pl-middle-layer': 1.52.1(@bytecodealliance/preview2-shim@0.17.8)
+      '@milaboratories/pl-tree': 1.9.2
       '@vitest/coverage-istanbul': 4.0.18(vitest@4.0.18(@types/node@24.5.2)(lightningcss@1.32.0)(yaml@2.8.1))
       vitest: 4.0.18(@types/node@24.5.2)(lightningcss@1.32.0)(yaml@2.8.1)
     transitivePeerDependencies:
@@ -6487,10 +6498,10 @@ snapshots:
       - tsx
       - yaml
 
-  '@platforma-sdk/ui-vue@1.59.4(typescript@5.6.3)':
+  '@platforma-sdk/ui-vue@1.60.2(typescript@5.6.3)':
     dependencies:
-      '@milaboratories/uikit': 2.10.46(typescript@5.6.3)
-      '@platforma-sdk/model': 1.59.3
+      '@milaboratories/uikit': 2.11.1(typescript@5.6.3)
+      '@platforma-sdk/model': 1.60.2
       '@types/d3-format': 3.0.4
       '@types/node': 24.5.2
       '@types/semver': 7.7.0
@@ -6519,10 +6530,10 @@ snapshots:
       - typescript
       - universal-cookie
 
-  '@platforma-sdk/workflow-tengo@5.10.1':
+  '@platforma-sdk/workflow-tengo@5.11.0':
     dependencies:
       '@milaboratories/software-pframes-conv': 2.2.9
-      '@platforma-open/milaboratories.software-ptabler': 1.14.3
+      '@platforma-open/milaboratories.software-ptabler': 1.15.0
       '@platforma-open/milaboratories.software-ptexter': 1.2.2
       '@platforma-open/milaboratories.software-small-binaries': 2.0.2
 
@@ -7464,6 +7475,20 @@ snapshots:
       path-browserify: 1.0.1
     optionalDependencies:
       typescript: 5.9.3
+
+  '@vue/language-core@2.2.12(typescript@5.6.3)':
+    dependencies:
+      '@volar/language-core': 2.4.15
+      '@vue/compiler-dom': 3.5.26
+      '@vue/compiler-vue2': 2.7.16
+      '@vue/shared': 3.5.26
+      alien-signals: 1.0.13
+      minimatch: 9.0.5
+      muggle-string: 0.4.1
+      path-browserify: 1.0.1
+    optionalDependencies:
+      typescript: 5.6.3
+    optional: true
 
   '@vue/language-core@2.2.12(typescript@5.9.3)':
     dependencies:
@@ -9163,7 +9188,7 @@ snapshots:
       rolldown: 1.0.0-rc.9
     optionalDependencies:
       typescript: 5.9.3
-      vue-tsc: 2.2.12(typescript@5.9.3)
+      vue-tsc: 2.2.12(typescript@5.6.3)
     transitivePeerDependencies:
       - oxc-resolver
 
@@ -9758,6 +9783,13 @@ snapshots:
       semver: 7.7.2
     transitivePeerDependencies:
       - supports-color
+
+  vue-tsc@2.2.12(typescript@5.6.3):
+    dependencies:
+      '@volar/typescript': 2.4.15
+      '@vue/language-core': 2.2.12(typescript@5.6.3)
+      typescript: 5.6.3
+    optional: true
 
   vue-tsc@2.2.12(typescript@5.9.3):
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -11,15 +11,15 @@ catalog:
   # SDK packages - EXACT VERSIONS (no ^ or ~)
   '@milaboratories/ts-builder': 1.3.0
   '@milaboratories/ts-configs': 1.2.2
-  '@platforma-sdk/workflow-tengo': 5.10.1
-  '@platforma-sdk/model': 1.59.3
-  '@platforma-sdk/ui-vue': 1.59.4
-  '@platforma-sdk/tengo-builder': 2.4.30
-  '@platforma-sdk/package-builder': 3.11.6
-  '@platforma-sdk/block-tools': 2.6.70
+  '@platforma-sdk/workflow-tengo': 5.11.0
+  '@platforma-sdk/model': 1.60.2
+  '@platforma-sdk/ui-vue': 1.60.2
+  '@platforma-sdk/tengo-builder': 2.5.1
+  '@platforma-sdk/package-builder': 3.12.0
+  '@platforma-sdk/block-tools': 2.7.1
   '@platforma-sdk/eslint-config': 1.2.0
-  '@platforma-sdk/test': 1.59.3
-  '@milaboratories/helpers': 1.13.7
+  '@platforma-sdk/test': 1.60.2
+  '@milaboratories/helpers': 1.14.0
   '@milaboratories/strings': 0.1.2
 
   # Common dependencies - can use ^ or ~

--- a/test/.oxfmtrc.json
+++ b/test/.oxfmtrc.json
@@ -1,0 +1,3 @@
+{
+  "ignorePatterns": ["dist", "CHANGELOG.md"]
+}

--- a/test/.oxlintrc.json
+++ b/test/.oxlintrc.json
@@ -1,0 +1,5 @@
+{
+  "extends": [
+    "node_modules/@milaboratories/ts-builder/dist/configs/oxlint-node.json"
+  ]
+}

--- a/test/eslint.config.mjs
+++ b/test/eslint.config.mjs
@@ -1,0 +1,4 @@
+import { test } from '@platforma-sdk/eslint-config';
+
+/** @type {import('eslint').Linter.Config[]} */
+export default [...test];

--- a/test/eslint.config.mjs
+++ b/test/eslint.config.mjs
@@ -1,5 +1,0 @@
-import { test } from '@platforma-sdk/eslint-config';
-
-/** @type {import('eslint').Linter.Config[]} */
-export default [...test];
-

--- a/ui/.oxfmtrc.json
+++ b/ui/.oxfmtrc.json
@@ -1,0 +1,3 @@
+{
+  "ignorePatterns": ["dist", "CHANGELOG.md"]
+}

--- a/ui/.oxlintrc.json
+++ b/ui/.oxlintrc.json
@@ -1,0 +1,5 @@
+{
+  "extends": [
+    "node_modules/@milaboratories/ts-builder/dist/configs/oxlint-block-ui.json"
+  ]
+}

--- a/ui/eslint.config.mjs
+++ b/ui/eslint.config.mjs
@@ -1,0 +1,4 @@
+import { ui } from '@platforma-sdk/eslint-config';
+
+/** @type {import('eslint').Linter.Config[]} */
+export default [...ui];

--- a/ui/eslint.config.mjs
+++ b/ui/eslint.config.mjs
@@ -1,4 +1,0 @@
-import { ui } from '@platforma-sdk/eslint-config';
-
-/** @type {import('eslint').Linter.Config[]} */
-export default [...ui];

--- a/ui/src/pages/MainPage.vue
+++ b/ui/src/pages/MainPage.vue
@@ -62,7 +62,7 @@ function setDataset(ref: PlRef | undefined) {
     <PlAlert v-if="!isValid" type="info">
       Please select a VDJ dataset and a new clonotype definition.
     </PlAlert>
-    <template v-else-if="isValid && !app.model.outputs.isRunning">
+    <template v-else-if="!app.model.outputs.isRunning">
       <PlAlert v-if="app.model.outputs.numberingWarning" type="warn">
         {{ app.model.outputs.numberingWarning }}
       </PlAlert>

--- a/ui/src/pages/MainPage.vue
+++ b/ui/src/pages/MainPage.vue
@@ -23,6 +23,11 @@ watchEffect(() => {
   }
 });
 
+const inputIsEmpty = computed(() => {
+  const stats = app.model.outputs.stats;
+  return stats !== undefined && stats.nClonotypesBefore === 0;
+});
+
 // Derive the warning message from numberingStats in the UI layer; the model provides raw facts.
 const numberingWarning = computed(() => {
   const ns = app.model.outputs.numberingStats;
@@ -76,6 +81,9 @@ const numberingWarning = computed(() => {
         {{ numberingWarning }}
       </PlAlert>
       <div class="results">
+        <PlAlert v-if="inputIsEmpty" type="warn">
+          The input dataset you have selected is empty. Please choose a different dataset.
+        </PlAlert>
         <div style="display: flex; align-items: center; justify-content: space-between;">
           <h3 style="margin: 0;">Results</h3>
           <PlBtnGhost v-if="app.model.outputs.anarciLog" @click.stop="() => (anarciLogOpen = true)">

--- a/ui/src/pages/MainPage.vue
+++ b/ui/src/pages/MainPage.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import type { PlRef } from '@platforma-sdk/model';
 import { PlAlert, PlBlockPage, PlBtnGhost, PlDropdown, PlDropdownMulti, PlDropdownRef, PlLogView, PlMaskIcon24, PlSlideModal } from '@platforma-sdk/ui-vue';
 import { computed, ref, watchEffect } from 'vue';
 import { useApp } from '../app';
@@ -17,14 +16,25 @@ const numberingSchemeOptions = [
 ];
 
 watchEffect(() => {
-  if (app.model.args.anchorRef === undefined) {
+  // Reset scheme when dataset is cleared OR when the selected dataset does not support numbering.
+  // Strict === false avoids clearing while the output is still loading (undefined).
+  if (app.model.args.anchorRef === undefined || app.model.outputs.numberingAvailable === false) {
     app.model.args.numberingScheme = undefined;
   }
 });
 
-function setDataset(ref: PlRef | undefined) {
-  app.model.args.anchorRef = ref;
-}
+// Derive the warning message from numberingStats in the UI layer; the model provides raw facts.
+const numberingWarning = computed(() => {
+  const ns = app.model.outputs.numberingStats;
+  if (!ns) return undefined;
+  if (ns.numbered === 0) {
+    return `ANARCI could not number any of the ${ns.total.toLocaleString()} clonotypes. The framework regions may be too divergent from known germline sequences.`;
+  }
+  if (ns.numbered < ns.total * 0.5) {
+    return `ANARCI could only number ${ns.numbered.toLocaleString()} of ${ns.total.toLocaleString()} clonotypes. The framework regions may be divergent from known germline sequences. Unnumbered clonotypes are excluded from the output.`;
+  }
+  return undefined;
+});
 
 </script>
 
@@ -38,7 +48,6 @@ function setDataset(ref: PlRef | undefined) {
       v-model="app.model.args.anchorRef"
       label="VDJ dataset"
       :options="app.model.outputs.datasetOptions"
-      @update:model-value="setDataset"
     />
     <PlDropdownMulti
       v-model="app.model.args.clonotypeDefinition"
@@ -63,8 +72,8 @@ function setDataset(ref: PlRef | undefined) {
       Please select a VDJ dataset and a new clonotype definition.
     </PlAlert>
     <template v-else-if="!app.model.outputs.isRunning">
-      <PlAlert v-if="app.model.outputs.numberingWarning" type="warn">
-        {{ app.model.outputs.numberingWarning }}
+      <PlAlert v-if="numberingWarning" type="warn">
+        {{ numberingWarning }}
       </PlAlert>
       <div class="results">
         <div style="display: flex; align-items: center; justify-content: space-between;">

--- a/workflow/src/main.tpl.tengo
+++ b/workflow/src/main.tpl.tengo
@@ -1076,7 +1076,7 @@ wf.body(func(args) {
 			name: "pl7.app/label",
 			valueType: "String",
 			annotations: {
-				"pl7.app/label": "Clone label",
+				"pl7.app/label": "Clone Id",
 				"pl7.app/table/orderPriority": "100000",
 				"pl7.app/table/visibility": "optional"
 			}

--- a/workflow/src/main.tpl.tengo
+++ b/workflow/src/main.tpl.tengo
@@ -728,8 +728,11 @@ wf.body(func(args) {
 
 	normExpressions := []
 	for header, _ in abundanceHeaders {
-		normExpressions = append(normExpressions, 
-			pt.col(header).truediv(pt.col(header + "_total")).alias("normalized_" + header)
+		// Cast to Double before division: polars CSE can infer an unexpected String type for the
+		// totals column when both this plan and sampleTotalsDf share the same base scan, causing
+		// "division with 'String' datatypes is not allowed". Explicit casts make this robust.
+		normExpressions = append(normExpressions,
+			pt.col(header).cast("Double").truediv(pt.col(header + "_total").cast("Double")).alias("normalized_" + header)
 		)
 	}
 	df_abundances = df_abundances.withColumns(normExpressions...)


### PR DESCRIPTION
## Summary

- When ANARCI numbers zero clonotypes (e.g. IG Light-only dataset where no sequences match the germline), the normalization step crashed with `division with 'String' datatypes is not allowed`
- Root cause: polars' CSE optimizer merges `df_abundances` and `sampleTotalsDf` into a vertical concat (they share the same base scan); when resolving the unified schema, missing columns are coerced to null/String, making `abundance_N_total` a String type — breaking `truediv`
- Fix: cast abundance columns to `Double` before dividing; Add warning to users when the input is 0.

## Test plan

- [x] Run Redefine Clonotypes against a single-chain VDJ dataset (e.g. IG Light only) with a numbering scheme selected
- [x] Confirm the block completes without error and the ANARCI warning is shown in the UI
- [x] Confirm the block still works correctly on a paired (H+KL) dataset with numbering enabled
- [x] Confirm the block still works correctly without numbering enabled


## Previous Error State

<img width="941" height="635" alt="Screenshot 2026-03-17 at 2 37 10 PM" src="https://github.com/user-attachments/assets/e7e5e26b-dd5b-4326-a94c-9e5b4386e2c5" />
<img width="936" height="630" alt="Screenshot 2026-03-17 at 2 37 01 PM" src="https://github.com/user-attachments/assets/8cb7060c-782a-4952-aedd-a4eb1bebd5fd" />


## After Fix - All Numbering Schema Still Work

<img width="1367" height="610" alt="Screenshot 2026-03-18 at 1 37 16 PM" src="https://github.com/user-attachments/assets/74125a85-7e7c-4ad1-8873-8a328103e042" />
<img width="1366" height="522" alt="Screenshot 2026-03-18 at 1 36 58 PM" src="https://github.com/user-attachments/assets/f9e7d9b7-bbca-4c55-bbfa-93c2818cb607" />


## After Fix - VDJ Datasets with values still continue to work

<img width="1365" height="481" alt="Screenshot 2026-03-18 at 1 36 44 PM" src="https://github.com/user-attachments/assets/eb7bee2e-4179-4d3c-bbde-2e02b3563ead" />
<img width="1361" height="519" alt="Screenshot 2026-03-18 at 1 36 35 PM" src="https://github.com/user-attachments/assets/adaf19d4-5778-4286-8d91-f8a027825849" />

