### PR TITLE
Add redefineSourceCount export column (convergence metric)

### DIFF
--- a/.changeset/redefine-source-count.md
+++ b/.changeset/redefine-source-count.md
@@ -1,0 +1,6 @@
+---
+'@platforma-open/milaboratories.redefine-clonotypes.workflow': minor
+'@platforma-open/milaboratories.redefine-clonotypes': minor
+---
+
+Add `pl7.app/vdj/redefineSourceCount` export column: per redefined clonotype, the number of distinct original clonotypes that were merged into it. Usable as a convergence metric in downstream blocks.

--- a/workflow/src/process.tpl.tengo
+++ b/workflow/src/process.tpl.tengo
@@ -653,6 +653,18 @@ self.body(func(inputs) {
 					"pl7.app/table/visibility": "optional"
 				}
 			}
+		}, {
+			column: "redefineSourceCount",
+			spec: {
+				name: "pl7.app/vdj/redefineSourceCount",
+				valueType: "Long",
+				annotations: {
+					"pl7.app/label": "Source Clonotypes",
+					"pl7.app/description": "Number of original clonotypes merged into this redefined clonotype (convergence metric)",
+					"pl7.app/min": "1",
+					"pl7.app/table/visibility": "optional"
+				}
+			}
 		}]
 
 		// Build existing sequence feature keys for CDR3 fallback logic
@@ -1002,6 +1014,13 @@ self.body(func(inputs) {
 			}
 		}
 		aggregatedDf := df_properties.groupBy("newClonotypeKey").agg(aggExpressions...)
+
+		// Convergence metric: how many distinct original clonotypes were merged into each new key.
+		// Computed from dfWithNewKeyStr (post numbering-filter) so totals match nClonotypesAfter.
+		sourceCountDf := dfWithNewKeyStr.
+			groupBy("newClonotypeKey").
+			agg(pt.col("clonotypeKey").nUnique().alias("redefineSourceCount"))
+		aggregatedDf = aggregatedDf.join(sourceCountDf, {on: "newClonotypeKey", how: "left"})
 
 		// label clonotype key deterministically on unique keys
 		aggregatedDf = addClonotypeLabelColumnsPt(aggregatedDf, "newClonotypeKey", "clonotypeLabel")


### PR DESCRIPTION
## Summary

- Adds a new export column `pl7.app/vdj/redefineSourceCount` (`valueType: Long`) on the redefined-clonotype axis.
- Per redefined clonotype, it counts the number of **distinct original clonotypes** that were merged into it by the chosen clonotype definition (sha256 over the selected definition columns).
- Intended as a **convergence metric** for downstream blocks.

## Implementation

- Computed inside the existing `pt.workflow` from `dfWithNewKeyStr` (i.e. the post numbering-filter frame), so totals are consistent with `nClonotypesAfter`. `sum(redefineSourceCount)` over all redefined keys equals the number of original clonotypes that survived the numbering filter.
- Joined into `aggregatedDf` on `newClonotypeKey` before `properties.tsv` is saved — the existing `xsv.importFile` then picks up the new column automatically based on its entry in `newPropertyColumns`.
- No domain on the column spec: the redefined-clonotype axis already carries `pl7.app/redefined-by: <blockId>` plus the encoded definition structure, which scopes the column to the specific redefine instance.
- No `pl7.app/format` annotation (integer column, default rendering); annotated with `pl7.app/min: "1"` and `pl7.app/table/visibility: "optional"`.

## Test plan

- [ ] Run an existing redefine pipeline and verify the new column appears in the result pool with `name = pl7.app/vdj/redefineSourceCount` on the redefined-clonotype axis.
- [ ] Verify `sum(redefineSourceCount)` over all redefined clonotypes equals `nClonotypesBefore` (when no numbering filter is active) or `nClonotypesAfter` totals (when numbering filter drops rows).
- [ ] Confirm a downstream block can discover and read the column via standard PColumn lookup.